### PR TITLE
Add HuggingFaceModel, HttpSouceModel

### DIFF
--- a/paka/kube_resources/model_group/model.py
+++ b/paka/kube_resources/model_group/model.py
@@ -8,7 +8,10 @@ from botocore.client import BaseClient, Config
 from botocore.exceptions import ClientError
 
 from paka.kube_resources.model_group.manifest import Manifest
-from paka.kube_resources.model_group.supported_models import SUPPORTED_MODELS
+from paka.kube_resources.model_group.supported_models import (
+    SUPPORTED_MODELS,
+    SUPPORTED_MODELS_V2,
+)
 from paka.logger import logger
 from paka.utils import read_current_cluster_data, to_yaml
 
@@ -204,47 +207,56 @@ def download_model(name: str) -> None:
     Returns:
         None
     """
-    if name not in SUPPORTED_MODELS:
-        logger.error(
-            f"Model {name} is not supported."
-            f"Available models are: {', '.join(SUPPORTED_MODELS.keys())}"
+
+    if name in SUPPORTED_MODELS_V2:
+        # new version of the model class
+        new_model = SUPPORTED_MODELS_V2[name]
+        if str(new_model) == "HuggingFaceModel":
+            new_model.upload_files()
+            return
+    else:
+        # old version
+        if name not in SUPPORTED_MODELS:
+            logger.error(
+                f"Model {name} is not supported."
+                f"Available models are: {', '.join(SUPPORTED_MODELS.keys())}"
+            )
+            raise Exception(f"Model {name} is not supported.")
+
+        model = SUPPORTED_MODELS[name]
+
+        logger.info(f"Downloading model from {model.url}...")
+        # Get the model name from the URL
+        model_file_name = model.url.split("/")[-1]
+        model_path = f"{MODEL_PATH_PREFIX}/{name}"
+
+        full_model_file_path = f"{model_path}/{model_file_name}"
+        bucket = read_current_cluster_data("bucket")
+
+        if s3_file_prefix_exists(bucket, f"{model_path}/"):
+            logger.info(f"Model {name} already exists.")
+            return
+
+        sha256 = download_file_to_s3(model.url, bucket, full_model_file_path)
+        if sha256 != model.sha256:
+            logger.error(f"SHA256 hash of the downloaded file does not match.")
+            # Delete the file
+            delete_s3_file(bucket, full_model_file_path)
+            raise Exception(f"SHA256 hash of the downloaded file does not match.")
+
+        # Save model manifest
+        manifest = Manifest(
+            name=name,
+            sha256=model.sha256,
+            url=model.url,
+            type="gguf",  # TODO: hard-coded for now
+            file=model_file_name,
         )
-        raise Exception(f"Model {name} is not supported.")
 
-    model = SUPPORTED_MODELS[name]
+        manifest_yaml = to_yaml(manifest.model_dump(exclude_none=True))
+        save_string_to_s3(bucket, f"{model_path}/manifest.yaml", manifest_yaml)
 
-    logger.info(f"Downloading model from {model.url}...")
-    # Get the model name from the URL
-    model_file_name = model.url.split("/")[-1]
-    model_path = f"{MODEL_PATH_PREFIX}/{name}"
-
-    full_model_file_path = f"{model_path}/{model_file_name}"
-    bucket = read_current_cluster_data("bucket")
-
-    if s3_file_prefix_exists(bucket, f"{model_path}/"):
-        logger.info(f"Model {name} already exists.")
-        return
-
-    sha256 = download_file_to_s3(model.url, bucket, full_model_file_path)
-    if sha256 != model.sha256:
-        logger.error(f"SHA256 hash of the downloaded file does not match.")
-        # Delete the file
-        delete_s3_file(bucket, full_model_file_path)
-        raise Exception(f"SHA256 hash of the downloaded file does not match.")
-
-    # Save model manifest
-    manifest = Manifest(
-        name=name,
-        sha256=model.sha256,
-        url=model.url,
-        type="gguf",  # TODO: hard-coded for now
-        file=model_file_name,
-    )
-
-    manifest_yaml = to_yaml(manifest.model_dump(exclude_none=True))
-    save_string_to_s3(bucket, f"{model_path}/manifest.yaml", manifest_yaml)
-
-    logger.info(f"Model {name} downloaded successfully.")
+        logger.info(f"Model {name} downloaded successfully.")
 
 
 def get_model_file_name(model_name: str) -> str:

--- a/paka/kube_resources/model_group/model.py
+++ b/paka/kube_resources/model_group/model.py
@@ -11,6 +11,7 @@ from paka.kube_resources.model_group.manifest import Manifest
 from paka.kube_resources.model_group.supported_models import (
     SUPPORTED_MODELS,
     SUPPORTED_MODELS_V2,
+    SUPPORTED_MODELS_V3,
 )
 from paka.logger import logger
 from paka.utils import read_current_cluster_data, to_yaml
@@ -207,12 +208,17 @@ def download_model(name: str) -> None:
     Returns:
         None
     """
-
-    if name in SUPPORTED_MODELS_V2:
-        # new version of the model class
-        new_model = SUPPORTED_MODELS_V2[name]
-        if str(new_model) == "HuggingFaceModel":
-            new_model.upload_files()
+    if name in SUPPORTED_MODELS_V3:
+        # http source model class
+        hugging_face_model = SUPPORTED_MODELS_V3[name]
+        if str(hugging_face_model) == "HttpSourceModel":
+            hugging_face_model.upload_files()
+            return
+    elif name in SUPPORTED_MODELS_V2:
+        # hugging face model class
+        http_source_model = SUPPORTED_MODELS_V2[name]
+        if str(http_source_model) == "HuggingFaceModel":
+            http_source_model.upload_files()
             return
     else:
         # old version

--- a/paka/kube_resources/model_group/models/abstract.py
+++ b/paka/kube_resources/model_group/models/abstract.py
@@ -1,11 +1,10 @@
 import concurrent.futures
 import hashlib
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List
 
 import boto3
 import requests
-from botocore.client import BaseClient, Config
+from botocore.client import Config
 from botocore.exceptions import ClientError
 
 from paka.logger import logger
@@ -18,25 +17,52 @@ class Model:
     def __init__(
         self,
         name: str,
+        inference_devices: list[str] = ["cpu"],
+        quantization: str = "GPTQ",
+        runtime: str = "llama.cpp",
+        prompt_template: str = "chatml",
         download_max_concurrency: int = 10,
         s3_chunk_size: int = 8 * 1024 * 1024,
         s3_max_concurrency: int = 20,
-    ):
+    ) -> None:
         """
         Initializes a Model object.
 
         Args:
             name (str): The name of the model, repository id.
-            download_max_concurrency (int): The maximum number of concurrent downloads.
-            s3_chunk_size (int): The size of each chunk to upload to S3 in bytes.
-            s3_max_concurrency (int): The maximum number of concurrent uploads to S3.
+            inference_devices (list[str], optional): The list (cpu, gpu, tpu, etc) of inference devices to use. Defaults to ['cpu'].
+            quantization (str, optional): The quantization method (GPTQ, AWQ, GGUF_Q4_0, etc) to use. Defaults to 'GPTQ'.
+            runtime (str, optional): The runtime (vLLM, pytorch, etc) to use. Defaults to 'llama.cpp'.
+            prompt_template (str, optional): The prompt template (chatml, llama-2, gemma, etc) to use. Defaults to 'chatml'.
+            download_max_concurrency (int, optional): The maximum number of concurrent downloads. Defaults to 10.
+            s3_chunk_size (int, optional): The size of each chunk to upload to S3 in bytes. Defaults to 8 * 1024 * 1024.
+            s3_max_concurrency (int, optional): The maximum number of concurrent uploads to S3. Defaults to 20.
         """
+        # model info
         self.name = name
-        self.bucket = read_current_cluster_data("bucket")
+        self.inference_devices = inference_devices
+        self.quantization = quantization
+        self.runtime = runtime
+        self.prompt_template = prompt_template
+
+        # s3 bucket
+        self.s3_bucket = read_current_cluster_data("bucket")
         self.s3_chunk_size = s3_chunk_size
         self.download_max_concurrency = download_max_concurrency
         self.s3_max_concurrency = s3_max_concurrency
         self.s3 = boto3.client("s3", config=Config(signature_version="s3v4"))
+
+    def get_s3_file_path(self, file_path: str) -> str:
+        """
+        Returns the S3 file path for a given file name.
+
+        Args:
+            file_path (str): The path of the file.
+
+        Returns:
+            str: The S3 file path.
+        """
+        return f"{MODEL_PATH_PREFIX}/{file_path}"
 
     def download(self, url: str, sha256: str | None = None) -> None:
         """
@@ -49,7 +75,9 @@ class Model:
         Raises:
             Exception: If the SHA256 hash of the downloaded file does not match the expected value.
         """
-        full_model_file_path = f"{MODEL_PATH_PREFIX}/{self.name}/{url.split('/')[-1]}"
+        full_model_file_path = self.get_s3_file_path(
+            f"{self.name}/{url.split(" / ")[-1]}"
+        )
         if self.s3_file_exists(full_model_file_path):
             logger.info(f"Model file {full_model_file_path} already exists.")
             return
@@ -74,8 +102,21 @@ class Model:
             # If an error occurred and upload was not completed
             if completed_upload_id is None:
                 self.s3.abort_multipart_upload(
-                    Bucket=self.bucket, Key=full_model_file_path, UploadId=upload_id
+                    Bucket=self.s3_bucket, Key=full_model_file_path, UploadId=upload_id
                 )
+
+    def download_all(self, urls: list[str], sha256s: list[str | None] = []) -> None:
+        """
+        Downloads multiple files from a list of URLs.
+
+        Args:
+            urls (list[str]): A list of URLs of the files to download.
+            sha256s (list[str], optional): A list of expected SHA256 hashes for the downloaded files.
+        """
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.download_max_concurrency
+        ) as executor:
+            executor.map(self.download, urls, sha256s)
 
     def upload_to_s3(
         self, response: requests.Response, s3_file_name: str
@@ -95,7 +136,9 @@ class Model:
         total_size = int(response.headers.get("content-length", 0))
         processed_size = 0
 
-        upload = self.s3.create_multipart_upload(Bucket=self.bucket, Key=s3_file_name)
+        upload = self.s3.create_multipart_upload(
+            Bucket=self.s3_bucket, Key=s3_file_name
+        )
         upload_id = upload["UploadId"]
         parts = []
 
@@ -136,7 +179,78 @@ class Model:
 
         parts.sort(key=lambda part: part["PartNumber"])
         self.s3.complete_multipart_upload(
-            Bucket=self.bucket,
+            Bucket=self.s3_bucket,
+            Key=s3_file_name,
+            UploadId=upload_id,
+            MultipartUpload={"Parts": parts},
+        )
+
+        logger.info(f"File uploaded to S3: {s3_file_name}")
+        sha256_value = sha256.hexdigest()
+        logger.info(f"SHA256 hash of the file: {sha256_value}")
+        return upload_id, sha256_value
+
+    def upload_fs_to_s3(
+        self, fs: Any, total_size: int, s3_file_name: str
+    ) -> tuple[Any, str]:
+        """
+        Uploads a single file to S3.
+
+        Args:
+            fs (Any): The file stream object.
+            total_size (int): The total size of the file.
+            s3_file_name (str): The name of the file in S3.
+
+        Returns:
+            tuple: A tuple containing the upload ID and the SHA256 hash of the file.
+        """
+        logger.info(f"Uploading model to {s3_file_name}")
+        sha256 = hashlib.sha256()
+        processed_size = 0
+        upload = self.s3.create_multipart_upload(
+            Bucket=self.s3_bucket, Key=s3_file_name
+        )
+        upload_id = upload["UploadId"]
+        parts = []
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.s3_max_concurrency
+        ) as executor:
+            futures: List[concurrent.futures.Future] = []
+            part_number = 1
+
+            for chunk in iter(lambda: fs.read(self.s3_chunk_size), b""):
+                sha256.update(chunk)
+                while len(futures) >= self.s3_max_concurrency:
+                    # Wait for one of the uploads to complete
+                    done, _ = concurrent.futures.wait(
+                        futures, return_when=concurrent.futures.FIRST_COMPLETED
+                    )
+                    for future in done:
+                        parts.append(future.result())
+                        futures.remove(future)
+
+                # Submit new chunk for upload
+                future = executor.submit(
+                    self.upload_part,
+                    s3_file_name,
+                    upload_id,
+                    part_number,
+                    chunk,
+                )
+                futures.append(future)
+                part_number += 1
+                processed_size += len(chunk)
+                progress = (processed_size / total_size) * 100
+                print(f"Progress: {progress:.2f}%", end="\r")
+
+            # Wait for all remaining uploads to complete
+            for future in concurrent.futures.as_completed(futures):
+                parts.append(future.result())
+
+        parts.sort(key=lambda part: part["PartNumber"])
+        self.s3.complete_multipart_upload(
+            Bucket=self.s3_bucket,
             Key=s3_file_name,
             UploadId=upload_id,
             MultipartUpload={"Parts": parts},
@@ -168,27 +282,12 @@ class Model:
         """
         part = self.s3.upload_part(
             Body=chunk,
-            Bucket=self.bucket,
+            Bucket=self.s3_bucket,
             Key=s3_file_name,
             UploadId=upload_id,
             PartNumber=part_number,
         )
         return {"PartNumber": part_number, "ETag": part["ETag"]}
-
-    def download_all(self, urls: list[str], sha256s: list[str | None] = []) -> None:
-        """
-        Downloads multiple files from a list of URLs.
-
-        Args:
-            urls (list[str]): A list of URLs of the files to download.
-            sha256s (list[str], optional): A list of expected SHA256 hashes for the downloaded files.
-        """
-        with ThreadPoolExecutor(max_workers=self.download_max_concurrency) as executor:
-            executor.map(
-                lambda url, index: self.download(url, get_item(sha256s, index)),
-                urls,
-                range(len(urls)),
-            )
 
     def s3_file_exists(self, s3_file_name: str) -> bool:
         """
@@ -200,9 +299,8 @@ class Model:
         Returns:
             bool: True if the file exists, False otherwise.
         """
-        s3 = boto3.client("s3")
         try:
-            s3.head_object(Bucket=self.bucket, Key=s3_file_name)
+            self.s3.head_object(Bucket=self.s3_bucket, Key=s3_file_name)
             return True
         except ClientError as e:
             if e.response["Error"]["Code"] == "404":
@@ -220,6 +318,21 @@ class Model:
         Returns:
             bool: True if the file prefix exists, False otherwise.
         """
-        s3 = boto3.resource("s3")
-        bucket = s3.Bucket(self.bucket)
+        bucket = self.s3.Bucket(self.s3_bucket)
         return any(bucket.objects.filter(Prefix=s3_file_name))
+
+    def delete_s3_file(self, s3_file_name: str) -> None:
+        """
+        Deletes the specified file from the S3 bucket.
+
+        Args:
+            s3_file_name (str): The name of the file to be deleted.
+
+        Returns:
+            None
+        """
+        if self.s3_file_exists(s3_file_name):
+            self.s3.delete_object(Bucket=self.s3_bucket, Key=s3_file_name)
+            logger.info(f"{s3_file_name} deleted.")
+        else:
+            logger.info(f"{s3_file_name} not found.")

--- a/paka/kube_resources/model_group/models/abstract.py
+++ b/paka/kube_resources/model_group/models/abstract.py
@@ -1,0 +1,225 @@
+import concurrent.futures
+import hashlib
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List
+
+import boto3
+import requests
+from botocore.client import BaseClient, Config
+from botocore.exceptions import ClientError
+
+from paka.logger import logger
+from paka.utils import get_item, read_current_cluster_data
+
+MODEL_PATH_PREFIX = "models"
+
+
+class Model:
+    def __init__(
+        self,
+        name: str,
+        download_max_concurrency: int = 10,
+        s3_chunk_size: int = 8 * 1024 * 1024,
+        s3_max_concurrency: int = 20,
+    ):
+        """
+        Initializes a Model object.
+
+        Args:
+            name (str): The name of the model, repository id.
+            download_max_concurrency (int): The maximum number of concurrent downloads.
+            s3_chunk_size (int): The size of each chunk to upload to S3 in bytes.
+            s3_max_concurrency (int): The maximum number of concurrent uploads to S3.
+        """
+        self.name = name
+        self.bucket = read_current_cluster_data("bucket")
+        self.s3_chunk_size = s3_chunk_size
+        self.download_max_concurrency = download_max_concurrency
+        self.s3_max_concurrency = s3_max_concurrency
+        self.s3 = boto3.client("s3", config=Config(signature_version="s3v4"))
+
+    def download(self, url: str, sha256: str | None = None) -> None:
+        """
+        Downloads a single file from a URL.
+
+        Args:
+            url (str): The URL of the file to download.
+            sha256 (str, optional): The expected SHA256 hash of the downloaded file.
+
+        Raises:
+            Exception: If the SHA256 hash of the downloaded file does not match the expected value.
+        """
+        full_model_file_path = f"{MODEL_PATH_PREFIX}/{self.name}/{url.split('/')[-1]}"
+        if self.s3_file_exists(full_model_file_path):
+            logger.info(f"Model file {full_model_file_path} already exists.")
+            return
+
+        logger.info(f"Downloading model from {url}")
+        completed_upload_id = None
+        try:
+            with requests.get(url, stream=True) as response:
+                response.raise_for_status()
+                upload_id, sha256_value = self.upload_to_s3(
+                    response, full_model_file_path
+                )
+                if sha256 is not None and sha256 != sha256_value:
+                    raise Exception(
+                        f"SHA256 hash of the downloaded file does not match the expected value. {full_model_file_path}"
+                    )
+                completed_upload_id = upload_id
+        except Exception as e:
+            logger.error(f"An error occurred, download: {str(e)}")
+            raise e
+        finally:
+            # If an error occurred and upload was not completed
+            if completed_upload_id is None:
+                self.s3.abort_multipart_upload(
+                    Bucket=self.bucket, Key=full_model_file_path, UploadId=upload_id
+                )
+
+    def upload_to_s3(
+        self, response: requests.Response, s3_file_name: str
+    ) -> tuple[Any, str]:
+        """
+        Uploads a single file to S3.
+
+        Args:
+            response (requests.Response): The response object from the file download.
+            s3_file_name (str): The name of the file in S3.
+
+        Returns:
+            tuple: A tuple containing the upload ID and the SHA256 hash of the file.
+        """
+        logger.info(f"Uploading model to {s3_file_name}")
+        sha256 = hashlib.sha256()
+        total_size = int(response.headers.get("content-length", 0))
+        processed_size = 0
+
+        upload = self.s3.create_multipart_upload(Bucket=self.bucket, Key=s3_file_name)
+        upload_id = upload["UploadId"]
+        parts = []
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.s3_max_concurrency
+        ) as executor:
+            futures: List[concurrent.futures.Future] = []
+            part_number = 1
+
+            for chunk in response.iter_content(chunk_size=self.s3_chunk_size):
+                sha256.update(chunk)
+                while len(futures) >= self.s3_max_concurrency:
+                    # Wait for one of the uploads to complete
+                    done, _ = concurrent.futures.wait(
+                        futures, return_when=concurrent.futures.FIRST_COMPLETED
+                    )
+                    for future in done:
+                        parts.append(future.result())
+                        futures.remove(future)
+
+                # Submit new chunk for upload
+                future = executor.submit(
+                    self.upload_part,
+                    s3_file_name,
+                    upload_id,
+                    part_number,
+                    chunk,
+                )
+                futures.append(future)
+                part_number += 1
+                processed_size += len(chunk)
+                progress = (processed_size / total_size) * 100
+                print(f"Progress: {progress:.2f}%", end="\r")
+
+            # Wait for all remaining uploads to complete
+            for future in concurrent.futures.as_completed(futures):
+                parts.append(future.result())
+
+        parts.sort(key=lambda part: part["PartNumber"])
+        self.s3.complete_multipart_upload(
+            Bucket=self.bucket,
+            Key=s3_file_name,
+            UploadId=upload_id,
+            MultipartUpload={"Parts": parts},
+        )
+
+        logger.info(f"File uploaded to S3: {s3_file_name}")
+        sha256_value = sha256.hexdigest()
+        logger.info(f"SHA256 hash of the file: {sha256_value}")
+        return upload_id, sha256_value
+
+    def upload_part(
+        self,
+        s3_file_name: str,
+        upload_id: str,
+        part_number: int,
+        chunk: bytes,
+    ) -> Dict[str, Any]:
+        """
+        Uploads a part of a file to S3.
+
+        Args:
+            s3_file_name (str): The name of the file in S3.
+            upload_id (str): The upload ID of the multipart upload.
+            part_number (int): The part number of the chunk being uploaded.
+            chunk (bytes): The chunk of data to upload.
+
+        Returns:
+            dict: A dictionary containing the part number and the ETag of the uploaded part.
+        """
+        part = self.s3.upload_part(
+            Body=chunk,
+            Bucket=self.bucket,
+            Key=s3_file_name,
+            UploadId=upload_id,
+            PartNumber=part_number,
+        )
+        return {"PartNumber": part_number, "ETag": part["ETag"]}
+
+    def download_all(self, urls: list[str], sha256s: list[str | None] = []) -> None:
+        """
+        Downloads multiple files from a list of URLs.
+
+        Args:
+            urls (list[str]): A list of URLs of the files to download.
+            sha256s (list[str], optional): A list of expected SHA256 hashes for the downloaded files.
+        """
+        with ThreadPoolExecutor(max_workers=self.download_max_concurrency) as executor:
+            executor.map(
+                lambda url, index: self.download(url, get_item(sha256s, index)),
+                urls,
+                range(len(urls)),
+            )
+
+    def s3_file_exists(self, s3_file_name: str) -> bool:
+        """
+        Checks if a file exists in S3.
+
+        Args:
+            s3_file_name (str): The name of the file in S3.
+
+        Returns:
+            bool: True if the file exists, False otherwise.
+        """
+        s3 = boto3.client("s3")
+        try:
+            s3.head_object(Bucket=self.bucket, Key=s3_file_name)
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                return False
+            else:
+                raise  # some other error occurred
+
+    def s3_file_prefix_exists(self, s3_file_name: str) -> bool:
+        """
+        Checks if a file prefix exists in S3.
+
+        Args:
+            s3_file_name (str): The prefix of the file name in S3.
+
+        Returns:
+            bool: True if the file prefix exists, False otherwise.
+        """
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket(self.bucket)
+        return any(bucket.objects.filter(Prefix=s3_file_name))

--- a/paka/kube_resources/model_group/models/abstract.py
+++ b/paka/kube_resources/model_group/models/abstract.py
@@ -76,7 +76,7 @@ class Model:
             Exception: If the SHA256 hash of the downloaded file does not match the expected value.
         """
         full_model_file_path = self.get_s3_file_path(
-            f"{self.name}/{url.split(" / ")[-1]}"
+            f"{self.name}/{url.split('/')[-1]}"
         )
         if self.s3_file_exists(full_model_file_path):
             logger.info(f"Model file {full_model_file_path} already exists.")

--- a/paka/kube_resources/model_group/models/base.py
+++ b/paka/kube_resources/model_group/models/base.py
@@ -91,6 +91,7 @@ class Model:
                     response, full_model_file_path
                 )
                 if sha256 is not None and sha256 != sha256_value:
+                    self.delete_s3_file(full_model_file_path)
                     raise Exception(
                         f"SHA256 hash of the downloaded file does not match the expected value. {full_model_file_path}"
                     )

--- a/paka/kube_resources/model_group/models/base.py
+++ b/paka/kube_resources/model_group/models/base.py
@@ -1,11 +1,13 @@
 import concurrent.futures
 import hashlib
+from threading import Lock
 from typing import Any, Dict, List
 
 import boto3
 import requests
 from botocore.client import Config
 from botocore.exceptions import ClientError
+from tqdm import tqdm
 
 from paka.logger import logger
 from paka.utils import read_current_cluster_data
@@ -51,6 +53,11 @@ class Model:
         self.download_max_concurrency = download_max_concurrency
         self.s3_max_concurrency = s3_max_concurrency
         self.s3 = boto3.client("s3", config=Config(signature_version="s3v4"))
+        # Shared counter
+        self.counter: dict[str, int] = {}
+        self.counter_lock = Lock()
+        self.pbar: tqdm = None
+        self.completed_files: list[tuple[str, str]] = []
 
     def get_s3_file_path(self, file_path: str) -> str:
         """
@@ -64,7 +71,13 @@ class Model:
         """
         return f"{MODEL_PATH_PREFIX}/{file_path}"
 
-    def download(self, url: str, sha256: str | None = None) -> None:
+    def download(
+        self,
+        url: str,
+        response: requests.Response | Any,
+        total_size: int,
+        sha256: str = "",
+    ) -> None:
         """
         Downloads a single file from a URL.
 
@@ -75,189 +88,127 @@ class Model:
         Raises:
             Exception: If the SHA256 hash of the downloaded file does not match the expected value.
         """
+        with self.counter_lock:
+            if self.pbar is None:
+                self.create_pbar(total_size)
+
         full_model_file_path = self.get_s3_file_path(
             f"{self.name}/{url.split('/')[-1]}"
         )
-        if self.s3_file_exists(full_model_file_path):
-            logger.info(f"Model file {full_model_file_path} already exists.")
-            return
 
-        logger.info(f"Downloading model from {url}")
-        completed_upload_id = None
+        upload_id = None
+        file_uploaded = False
         try:
-            with requests.get(url, stream=True) as response:
-                response.raise_for_status()
-                upload_id, sha256_value = self.upload_to_s3(
-                    response, full_model_file_path
+            if full_model_file_path not in self.counter:
+                with self.counter_lock:
+                    if self.pbar is not None:
+                        self.pbar.total += total_size
+                        self.pbar.refresh()
+
+            if self.s3_file_exists(full_model_file_path):
+                logger.info(f"Model source already exists in {full_model_file_path}.")
+                self.update_progress(full_model_file_path, total_size)
+                return
+
+            upload = self.s3.create_multipart_upload(
+                Bucket=self.s3_bucket, Key=full_model_file_path
+            )
+            upload_id = upload["UploadId"]
+            sha256_value = self.upload_to_s3(response, full_model_file_path, upload_id)
+            if sha256 and sha256 != sha256_value:
+                self.delete_s3_file(full_model_file_path)
+                raise Exception(
+                    f"SHA256 hash of the downloaded file does not match the expected value. {full_model_file_path}"
                 )
-                if sha256 is not None and sha256 != sha256_value:
-                    self.delete_s3_file(full_model_file_path)
-                    raise Exception(
-                        f"SHA256 hash of the downloaded file does not match the expected value. {full_model_file_path}"
-                    )
-                completed_upload_id = upload_id
+            file_uploaded = True
         except Exception as e:
-            logger.error(f"An error occurred, download: {str(e)}")
+            self.logging_for_class(f"An error occurred: {str(e)}", "error")
             raise e
         finally:
             # If an error occurred and upload was not completed
-            if completed_upload_id is None:
+            if upload_id is not None and not file_uploaded:
                 self.s3.abort_multipart_upload(
                     Bucket=self.s3_bucket, Key=full_model_file_path, UploadId=upload_id
                 )
-
-    def download_all(self, urls: list[str], sha256s: list[str | None] = []) -> None:
-        """
-        Downloads multiple files from a list of URLs.
-
-        Args:
-            urls (list[str]): A list of URLs of the files to download.
-            sha256s (list[str], optional): A list of expected SHA256 hashes for the downloaded files.
-        """
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self.download_max_concurrency
-        ) as executor:
-            executor.map(self.download, urls, sha256s)
+            else:
+                self.logging_for_class(
+                    f"Model file {full_model_file_path} uploaded successfully."
+                )
+                self.completed_files.append((url, sha256))
+                self.update_progress()
 
     def upload_to_s3(
-        self, response: requests.Response, s3_file_name: str
-    ) -> tuple[Any, str]:
-        """
-        Uploads a single file to S3.
-
-        Args:
-            response (requests.Response): The response object from the file download.
-            s3_file_name (str): The name of the file in S3.
-
-        Returns:
-            tuple: A tuple containing the upload ID and the SHA256 hash of the file.
-        """
-        logger.info(f"Uploading model to {s3_file_name}")
-        sha256 = hashlib.sha256()
-        total_size = int(response.headers.get("content-length", 0))
-        processed_size = 0
-
-        upload = self.s3.create_multipart_upload(
-            Bucket=self.s3_bucket, Key=s3_file_name
-        )
-        upload_id = upload["UploadId"]
-        parts = []
-
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self.s3_max_concurrency
-        ) as executor:
-            futures: List[concurrent.futures.Future] = []
-            part_number = 1
-
-            for chunk in response.iter_content(chunk_size=self.s3_chunk_size):
-                sha256.update(chunk)
-                while len(futures) >= self.s3_max_concurrency:
-                    # Wait for one of the uploads to complete
-                    done, _ = concurrent.futures.wait(
-                        futures, return_when=concurrent.futures.FIRST_COMPLETED
-                    )
-                    for future in done:
-                        parts.append(future.result())
-                        futures.remove(future)
-
-                # Submit new chunk for upload
-                future = executor.submit(
-                    self.upload_part,
-                    s3_file_name,
-                    upload_id,
-                    part_number,
-                    chunk,
-                )
-                futures.append(future)
-                part_number += 1
-                processed_size += len(chunk)
-                progress = (processed_size / total_size) * 100
-                print(f"Progress: {progress:.2f}%", end="\r")
-
-            # Wait for all remaining uploads to complete
-            for future in concurrent.futures.as_completed(futures):
-                parts.append(future.result())
-
-        parts.sort(key=lambda part: part["PartNumber"])
-        self.s3.complete_multipart_upload(
-            Bucket=self.s3_bucket,
-            Key=s3_file_name,
-            UploadId=upload_id,
-            MultipartUpload={"Parts": parts},
-        )
-
-        logger.info(f"File uploaded to S3: {s3_file_name}")
-        sha256_value = sha256.hexdigest()
-        logger.info(f"SHA256 hash of the file: {sha256_value}")
-        return upload_id, sha256_value
-
-    def upload_fs_to_s3(
-        self, fs: Any, total_size: int, s3_file_name: str, upload_id: str
+        self,
+        response: Any,
+        s3_file_name: str,
+        upload_id: str,
     ) -> str:
         """
         Uploads a single file to S3.
 
         Args:
-            fs (Any): The file stream object.
-            total_size (int): The total size of the file.
+            response (requests.Response | FileStream): The response object from the file download or the file stream object.
             s3_file_name (str): The name of the file in S3.
-            upload_id: The upload ID of the multipart upload.
+            upload_id (str): The upload ID of the multipart upload.
 
         Returns:
-            tuple: the SHA256 hash of the file.
+            str: The SHA256 hash of the uploaded file.
         """
-        logger.info(f"Uploading model to {s3_file_name}")
-        sha256 = hashlib.sha256()
-        processed_size = 0
-        parts = []
+        try:
+            self.pbar.postfix = f"{s3_file_name}"
+            sha256 = hashlib.sha256()
+            processed_size = 0
+            parts = []
 
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self.s3_max_concurrency
-        ) as executor:
-            futures: List[concurrent.futures.Future] = []
-            part_number = 1
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=self.s3_max_concurrency
+            ) as executor:
+                futures: List[concurrent.futures.Future] = []
+                part_number = 1
+                for chunk in (
+                    response.iter_content(chunk_size=self.s3_chunk_size)
+                    if "Response" in str(response)
+                    else iter(lambda: response.read(self.s3_chunk_size), b"")
+                ):
+                    sha256.update(chunk)
+                    while len(futures) >= self.s3_max_concurrency:
+                        done, _ = concurrent.futures.wait(
+                            futures, return_when=concurrent.futures.FIRST_COMPLETED
+                        )
+                        for future in done:
+                            parts.append(future.result())
+                            futures.remove(future)
 
-            for chunk in iter(lambda: fs.read(self.s3_chunk_size), b""):
-                sha256.update(chunk)
-                while len(futures) >= self.s3_max_concurrency:
-                    # Wait for one of the uploads to complete
-                    done, _ = concurrent.futures.wait(
-                        futures, return_when=concurrent.futures.FIRST_COMPLETED
+                    future = executor.submit(
+                        self.upload_part,
+                        s3_file_name,
+                        upload_id,
+                        part_number,
+                        chunk,
                     )
-                    for future in done:
-                        parts.append(future.result())
-                        futures.remove(future)
+                    futures.append(future)
+                    part_number += 1
+                    processed_size += len(chunk)
+                    self.update_progress(s3_file_name, processed_size)
 
-                # Submit new chunk for upload
-                future = executor.submit(
-                    self.upload_part,
-                    s3_file_name,
-                    upload_id,
-                    part_number,
-                    chunk,
-                )
-                futures.append(future)
-                part_number += 1
-                processed_size += len(chunk)
-                progress = (processed_size / total_size) * 100
-                print(f"Progress: {progress:.2f}%", end="\r")
+                for future in concurrent.futures.as_completed(futures):
+                    parts.append(future.result())
 
-            # Wait for all remaining uploads to complete
-            for future in concurrent.futures.as_completed(futures):
-                parts.append(future.result())
+            parts.sort(key=lambda part: part["PartNumber"])
+            self.s3.complete_multipart_upload(
+                Bucket=self.s3_bucket,
+                Key=s3_file_name,
+                UploadId=upload_id,
+                MultipartUpload={"Parts": parts},
+            )
 
-        parts.sort(key=lambda part: part["PartNumber"])
-        self.s3.complete_multipart_upload(
-            Bucket=self.s3_bucket,
-            Key=s3_file_name,
-            UploadId=upload_id,
-            MultipartUpload={"Parts": parts},
-        )
-
-        logger.info(f"File uploaded to S3: {s3_file_name}")
-        sha256_value = sha256.hexdigest()
-        logger.info(f"SHA256 hash of the file: {sha256_value}")
-        return sha256_value
+            sha256_value = sha256.hexdigest()
+            return sha256_value
+        except Exception as e:
+            self.logging_for_class(
+                f"An error occurred in upload_to_s3: {str(e)}", "error"
+            )
+            raise e
 
     def upload_part(
         self,
@@ -334,3 +285,40 @@ class Model:
             logger.info(f"{s3_file_name} deleted.")
         else:
             logger.info(f"{s3_file_name} not found.")
+
+    def clear_counter(self) -> None:
+        with self.counter_lock:
+            self.counter = {}
+
+    def create_pbar(self, total_size: int) -> None:
+        self.pbar = tqdm(total=total_size, unit="B", unit_scale=True, desc="Uploading")
+
+    def close_pbar(self) -> None:
+        self.pbar.close()
+        self.pbar = None
+
+    def update_progress(self, key: str = "", value: int = 0) -> None:
+        with self.counter_lock:
+            if key:
+                self.counter[key] = value
+            total_progress = sum(self.counter.values())
+            self.pbar.update(total_progress - self.pbar.n)
+
+    def logging_for_class(self, message: str, type: str = "info") -> None:
+        """
+        Logs an informational message.
+
+        Args:
+            message (str): The message to log.
+
+        Returns:
+            None
+        """
+        if type == "info":
+            logger.info(f"{self.__str__()} ({self.name}): {message}")
+        elif type == "warn":
+            logger.warn(f"{self.__str__()} ({self.name}): {message}")
+        elif type == "error":
+            logger.error(f"{self.__str__()} ({self.name}): {message}")
+        else:
+            logger.info(f"{self.__str__()} ({self.name}): {message}")

--- a/paka/kube_resources/model_group/models/http_source_model.py
+++ b/paka/kube_resources/model_group/models/http_source_model.py
@@ -12,7 +12,7 @@ from paka.utils import to_yaml
 
 class HttpSourceManifest(BaseModel):
     name: str
-    urls: list[str]
+    urls: list[tuple[str, str]]
     inference_devices: list[str]
     quantization: str
     runtime: str

--- a/paka/kube_resources/model_group/models/http_source_model.py
+++ b/paka/kube_resources/model_group/models/http_source_model.py
@@ -1,0 +1,116 @@
+import concurrent.futures
+from typing import Any
+
+import boto3
+import requests
+from pydantic import BaseModel
+
+from paka.kube_resources.model_group.models.base import Model
+from paka.logger import logger
+from paka.utils import to_yaml
+
+
+class HttpSourceManifest(BaseModel):
+    name: str
+    urls: list[str]
+    inference_devices: list[str]
+    quantization: str
+    runtime: str
+    prompt_template: str
+
+
+class HttpSourceModel(Model):
+    def __str__(self) -> str:
+        return "HttpSourceModel"
+
+    def __init__(
+        self,
+        name: str,
+        urls: list[str],
+        inference_devices: list[str] = ["cpu"],
+        quantization: str = "GPTQ",
+        runtime: str = "llama.cpp",
+        prompt_template: str = "chatml",
+        download_max_concurrency: int = 10,
+        s3_chunk_size: int = 8 * 1024 * 1024,
+        s3_max_concurrency: int = 20,
+    ) -> None:
+        super().__init__(
+            name,
+            inference_devices,
+            quantization,
+            runtime,
+            prompt_template,
+            download_max_concurrency,
+            s3_chunk_size,
+            s3_max_concurrency,
+        )
+        self.urls = urls
+
+    def save_manifest_yml(self) -> None:
+        """
+        Saves the HttpSourceManifest YAML file for the model.
+
+        This method creates a `HttpSourceManifest` object with the specified parameters and converts it to YAML format.
+        The resulting YAML is then saved to an S3 bucket with the file path "{name}/manifest.yml".
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
+        manifest = HttpSourceManifest(
+            name=self.name,
+            urls=self.completed_files,
+            inference_devices=self.inference_devices,
+            quantization=self.quantization,
+            runtime=self.runtime,
+            prompt_template=self.prompt_template,
+        )
+        manifest_yml = to_yaml(manifest.model_dump(exclude_none=True))
+        file_path = self.get_s3_file_path(f"{self.name}/manifest.yml")
+        s3 = boto3.resource("s3")
+        if self.s3_file_exists(file_path):
+            self.logging_for_class(
+                f"manifest.yml file already exists at {file_path}. Overwriting..."
+            )
+            s3.Object(self.s3_bucket, file_path).delete()
+        s3.Object(self.s3_bucket, file_path).put(Body=manifest_yml)
+        self.logging_for_class(f"manifest.yml file saved to {file_path}")
+
+    def upload(self, url: str) -> None:
+        with requests.get(url, stream=True) as response:
+            response.raise_for_status()
+            total_size = int(response.headers.get("content-length", 0))
+            self.download(url, response, total_size)
+
+    def upload_files(self) -> None:
+        """
+        Upload multiple files from http urls in parallel.
+        Returns:
+            None
+        """
+        self.logging_for_class("Uploading http sources to S3...")
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.download_max_concurrency
+        ) as executor:
+            futures = [executor.submit(self.upload, url) for url in self.urls]
+            concurrent.futures.wait(futures)
+            # Callback function to handle completion of all workers
+            self.handle_upload_completion()
+
+    def handle_upload_completion(self) -> None:
+        """
+        Callback function to handle completion of all workers.
+        This function will be called after all files have been uploaded.
+        Returns:
+            None
+        """
+        # Add your code here to handle the completion of all workers
+        # For example, you can log a message or perform any post-processing tasks
+        self.save_manifest_yml()
+        self.completed_files = []
+        self.clear_counter()
+        self.close_pbar()
+        self.logging_for_class("All files have been uploaded.")

--- a/paka/kube_resources/model_group/models/hugging_face_model.py
+++ b/paka/kube_resources/model_group/models/hugging_face_model.py
@@ -1,0 +1,78 @@
+from huggingface_hub import hf_hub_url, snapshot_download
+
+from paka.kube_resources.model_group.models.abstract import Model
+from paka.logger import logger
+
+
+class HuggingFaceModel(Model):
+    """
+    A class representing a Hugging Face model.
+
+    Args:
+        name (str): The name of the model.
+        files (list[tuple[str, str] | str], optional): A list of files to download for the model. Each file can be specified as a tuple containing the filename and its corresponding SHA256 hash, or as a string representing the filename. Defaults to None.
+
+    Attributes:
+        urls (list[str]): A list of URLs to download the files.
+        sha256s (list[str]): A list of SHA256 hashes corresponding to the files.
+
+    Methods:
+        define_urls(files: list[tuple[str, str] | str]) -> None: Defines the URLs and SHA256 hashes for the files.
+        download() -> None: Downloads the files.
+        snapshot_download(destination: str) -> None: Downloads the model using the Hugging Face snapshot_download function.
+
+    """
+
+    def __init__(self, name: str, files: list[tuple[str, str] | str] = []):
+        super().__init__(name)
+        self.urls: list[str] = []
+        self.sha256s: list[str | None] = []
+        if len(files) > 0:
+            self.define_urls(files)
+
+    def define_urls(self, files: list[tuple[str, str] | str]) -> None:
+        """
+        Defines the URLs and SHA256 hashes for the files.
+
+        Args:
+            files (list[tuple[str, str] | str]): A list of files to download for the model. Each file can be specified as a tuple containing the filename and its corresponding SHA256 hash, or as a string representing the filename.
+
+        Returns:
+            None
+
+        """
+        for file in files:
+            if isinstance(file, tuple):
+                self.urls.append(hf_hub_url(repo_id=self.name, filename=file[0]))
+                self.sha256s.append(file[1])
+            elif file is not None and file != "":
+                self.urls.append(hf_hub_url(repo_id=self.name, filename=file))
+                self.sha256s.append(None)
+
+    def save_to_s3(self) -> None:
+        """
+        Downloads the files.
+
+        Returns:
+            None
+
+        """
+        if len(self.urls) == 0:
+            logger.info("No files to download.")
+            return None
+        self.download_all(self.urls, self.sha256s)
+
+    def snapshot_download(self, destination: str) -> None:
+        """
+        Downloads the model using the Hugging Face snapshot_download function.
+
+        Args:
+            destination (str): The destination directory to save the downloaded model.
+
+        Returns:
+            None
+
+        """
+        # Implement the download logic for Hugging Face models here
+        snapshot_download(self.name, library_name="transformers", cache_dir=destination)
+        pass

--- a/paka/kube_resources/model_group/supported_models.py
+++ b/paka/kube_resources/model_group/supported_models.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 
+from paka.kube_resources.model_group.models.http_source_model import HttpSourceModel
 from paka.kube_resources.model_group.models.hugging_face_model import HuggingFaceModel
 
 Model = namedtuple("Model", ["name", "url", "sha256"])
@@ -35,5 +36,15 @@ SUPPORTED_MODELS_V2 = {
     "gte-base": HuggingFaceModel(
         repo_id="jjleng/gte-base-gguf",
         files=["gte-base.q4_0.gguf", "gte-base.f32.gguf", "gte-base.f16.gguf"],
+    ),
+}
+
+SUPPORTED_MODELS_V3 = {
+    "gte-base": HttpSourceModel(
+        name="jjleng/gte-base-gguf",
+        urls=[
+            "https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q4_0.gguf",
+            "https://huggingface.co/jjleng/gte-base-gguf/resolve/main/gte-base.q4_0.gguf",
+        ],
     ),
 }

--- a/paka/kube_resources/model_group/supported_models.py
+++ b/paka/kube_resources/model_group/supported_models.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
 
+from paka.kube_resources.model_group.models.hugging_face_model import HuggingFaceModel
+
 Model = namedtuple("Model", ["name", "url", "sha256"])
 
 SUPPORTED_MODELS = {
@@ -22,5 +24,16 @@ SUPPORTED_MODELS = {
         name="gte-base",
         url="https://huggingface.co/jjleng/gte-base-gguf/resolve/main/gte-base.q4_0.gguf",
         sha256="2413866ece3b8b9eedf6c2a4393d4b56dbfa363c173ca3ba3a2f2a44db158982",
+    ),
+}
+
+SUPPORTED_MODELS_V2 = {
+    "llama2-7b": HuggingFaceModel(
+        repo_id="TheBloke/Llama-2-7B-Chat-GGUF",
+        files=["*.json", "llama-2-7b-chat.Q4_0.gguf", "llama-2-7b-chat.Q3_K_S.gguf"],
+    ),
+    "gte-base": HuggingFaceModel(
+        repo_id="jjleng/gte-base-gguf",
+        files=["gte-base.q4_0.gguf", "gte-base.f32.gguf", "gte-base.f16.gguf"],
     ),
 }

--- a/paka/utils.py
+++ b/paka/utils.py
@@ -317,3 +317,13 @@ def random_str(length: int = 5) -> str:
         str: The generated random string.
     """
     return "".join(random.choices(string.ascii_letters + string.digits, k=length))
+
+
+def get_item(data: list[Any], index: int) -> Any:
+    """
+    Get an item from a list by index and return None if the index is out of bounds.
+    """
+    try:
+        return data[index]
+    except IndexError:
+        return None

--- a/paka/utils.py
+++ b/paka/utils.py
@@ -317,13 +317,3 @@ def random_str(length: int = 5) -> str:
         str: The generated random string.
     """
     return "".join(random.choices(string.ascii_letters + string.digits, k=length))
-
-
-def get_item(data: list[Any], index: int) -> Any:
-    """
-    Get an item from a list by index and return None if the index is out of bounds.
-    """
-    try:
-        return data[index]
-    except IndexError:
-        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ requests = "^2.31.0"
 kubernetes = "^v29.0.0b1"
 boto3 = "^1.34.22"
 tabulate = "^0.9.0"
+huggingface-hub = "^0.22.2"
 
 [tool.poetry.group.dev.dependencies]
 codespell = "^2.2.6"

--- a/tests/model_group/models/test_abstract.py
+++ b/tests/model_group/models/test_abstract.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from paka.kube_resources.model_group.models.abstract import Model
+
+
+class TestModel(unittest.TestCase):
+    def setUp(self) -> None:
+        self.model = Model("TheBloke/Llama-2-7B-Chat-GGUF")
+
+    @patch("paka.kube_resources.model_group.models.abstract.read_current_cluster_data")
+    @patch("paka.kube_resources.model_group.models.abstract.boto3.client")
+    def test_init(
+        self, mock_boto3_client: Mock, mock_read_current_cluster_data: Mock
+    ) -> None:
+        mock_read_current_cluster_data.return_value = "test_bucket"
+        self.model = Model(
+            "TheBloke/Llama-2-7B-Chat-GGUF",
+            download_max_concurrency=5,
+            s3_chunk_size=4 * 1024 * 1024,
+            s3_max_concurrency=10,
+        )
+        self.assertEqual(self.model.name, "TheBloke/Llama-2-7B-Chat-GGUF")
+        self.assertEqual(self.model.bucket, "test_bucket")
+        self.assertEqual(self.model.s3_chunk_size, 4 * 1024 * 1024)
+        self.assertEqual(self.model.download_max_concurrency, 5)
+        self.assertEqual(self.model.s3_max_concurrency, 10)
+        mock_read_current_cluster_data.assert_called_once_with("bucket")
+        # mock_boto3_client.assert_called_once_with("s3", config=MagicMock(signature_version="s3v4"))
+
+    @patch("paka.kube_resources.model_group.models.abstract.logger")
+    @patch("paka.kube_resources.model_group.models.abstract.requests.get")
+    @patch("paka.kube_resources.model_group.models.abstract.Model.s3_file_exists")
+    @patch("paka.kube_resources.model_group.models.abstract.Model.upload_part")
+    @patch("paka.kube_resources.model_group.models.abstract.Model.upload_to_s3")
+    def test_download(
+        self,
+        mock_upload_to_s3: Mock,
+        mock_upload_part: Mock,
+        mock_s3_file_exists: Mock,
+        mock_requests_get: Mock,
+        mock_logger: Mock,
+    ) -> None:
+        mock_s3_file_exists.return_value = False
+        mock_upload_part.return_value = {"PartNumber": 1, "ETag": "test_etag"}
+        mock_response = MagicMock()
+        mock_response.headers.get.return_value = "100"
+        mock_response.iter_content.return_value = [b"chunk1", b"chunk2"]
+        mock_response.raise_for_status.return_value = True
+        mock_requests_get.return_value.__enter__.return_value = mock_response
+        url = "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_0.gguf"
+        sha256 = "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b"
+        mock_upload_to_s3.return_value = ("test_upload_id", sha256)
+        self.model.download(url, sha256)
+        mock_s3_file_exists.assert_called_once_with(
+            "models/TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf"
+        )
+        mock_logger.info.assert_called_with(f"Downloading model from {url}")
+        mock_requests_get.assert_called_once_with(url, stream=True)
+        mock_response.raise_for_status.assert_called_once()
+        mock_upload_to_s3.assert_called_once_with(
+            mock_response,
+            "models/TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf",
+        )
+
+    # @patch("paka.kube_resources.model_group.models.abstract.logger")
+    # @patch("paka.kube_resources.model_group.models.abstract.requests.get")
+    # @patch("paka.kube_resources.model_group.models.abstract.Model.download")
+    # async def test_download_all(
+    #     self, mock_download: Mock, mock_requests_get: Mock, mock_logger: Mock
+    # ) -> None:
+    #     urls = [
+    #         "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_0.gguf",
+    #         "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q2_K.gguf",
+    #     ]
+    #     sha256s: list[str | None] = [
+    #         "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b",
+    #         "c0dd304d761e8e05d082cc2902d7624a7f87858fdfaa4ef098330ffe767ff0d3",
+    #     ]
+    #     mock_download = AsyncMock()
+    #     await self.model.download_all(urls, sha256s)
+    #     # Create a mock async iterator
+    #     mock_download.assert_awaited_with(urls[0], sha256s[0])
+    #     mock_download.assert_awaited_with(urls[1], sha256s[1])

--- a/tests/model_group/models/test_base.py
+++ b/tests/model_group/models/test_base.py
@@ -1,15 +1,15 @@
 import unittest
 from unittest.mock import ANY, MagicMock, Mock, patch
 
-from paka.kube_resources.model_group.models.abstract import Model
+from paka.kube_resources.model_group.models.base import Model
 
 
 class TestModel(unittest.TestCase):
     def setUp(self) -> None:
         self.model = Model("TheBloke/Llama-2-7B-Chat-GGUF")
 
-    @patch("paka.kube_resources.model_group.models.abstract.read_current_cluster_data")
-    @patch("paka.kube_resources.model_group.models.abstract.boto3.client")
+    @patch("paka.kube_resources.model_group.models.base.read_current_cluster_data")
+    @patch("paka.kube_resources.model_group.models.base.boto3.client")
     def test_init(
         self, mock_boto3_client: Mock, mock_read_current_cluster_data: Mock
     ) -> None:
@@ -28,11 +28,11 @@ class TestModel(unittest.TestCase):
         mock_read_current_cluster_data.assert_called_once_with("bucket")
         # mock_boto3_client.assert_called_once_with("s3", config=MagicMock(signature_version="s3v4"))
 
-    @patch("paka.kube_resources.model_group.models.abstract.logger")
-    @patch("paka.kube_resources.model_group.models.abstract.requests.get")
-    @patch("paka.kube_resources.model_group.models.abstract.Model.s3_file_exists")
-    @patch("paka.kube_resources.model_group.models.abstract.Model.upload_part")
-    @patch("paka.kube_resources.model_group.models.abstract.Model.upload_to_s3")
+    @patch("paka.kube_resources.model_group.models.base.logger")
+    @patch("paka.kube_resources.model_group.models.base.requests.get")
+    @patch("paka.kube_resources.model_group.models.base.Model.s3_file_exists")
+    @patch("paka.kube_resources.model_group.models.base.Model.upload_part")
+    @patch("paka.kube_resources.model_group.models.base.Model.upload_to_s3")
     def test_download(
         self,
         mock_upload_to_s3: Mock,

--- a/tests/model_group/models/test_base.py
+++ b/tests/model_group/models/test_base.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import ANY, MagicMock, Mock, patch
 
+import requests
+
 from paka.kube_resources.model_group.models.base import Model
 
 
@@ -28,52 +30,29 @@ class TestModel(unittest.TestCase):
         mock_read_current_cluster_data.assert_called_once_with("bucket")
         # mock_boto3_client.assert_called_once_with("s3", config=MagicMock(signature_version="s3v4"))
 
-    @patch("paka.kube_resources.model_group.models.base.logger")
-    @patch("paka.kube_resources.model_group.models.base.requests.get")
-    @patch("paka.kube_resources.model_group.models.base.Model.s3_file_exists")
-    @patch("paka.kube_resources.model_group.models.base.Model.upload_part")
-    @patch("paka.kube_resources.model_group.models.base.Model.upload_to_s3")
+    @patch("paka.kube_resources.model_group.models.base.read_current_cluster_data")
+    @patch("paka.kube_resources.model_group.models.base.boto3.client")
+    @patch("paka.kube_resources.model_group.models.base.requests")
+    @patch.object(Model, "upload_to_s3")
+    @patch.object(Model, "s3_file_exists")
     def test_download(
         self,
-        mock_upload_to_s3: Mock,
-        mock_upload_part: Mock,
         mock_s3_file_exists: Mock,
-        mock_requests_get: Mock,
-        mock_logger: Mock,
+        mock_upload_to_s3: Mock,
+        mock_requests: Mock,
+        mock_boto3_client: Mock,
+        mock_read_current_cluster_data: Mock,
     ) -> None:
         mock_s3_file_exists.return_value = False
-        mock_upload_part.return_value = {"PartNumber": 1, "ETag": "test_etag"}
-        mock_response = MagicMock()
-        mock_response.headers.get.return_value = "100"
-        mock_response.iter_content.return_value = [b"chunk1", b"chunk2"]
-        mock_response.raise_for_status.return_value = True
-        mock_requests_get.return_value.__enter__.return_value = mock_response
-        url = "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_0.gguf"
-        sha256 = "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b"
-        mock_upload_to_s3.return_value = ("test_upload_id", sha256)
-        self.model.download(url, sha256)
-        mock_s3_file_exists.assert_called_once_with(
-            "models/TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf"
-        )
-        mock_logger.info.assert_called_with(f"Downloading model from {url}")
-        mock_requests_get.assert_called_once_with(url, stream=True)
-        mock_response.raise_for_status.assert_called_once()
+        mock_read_current_cluster_data.return_value = "test_bucket"
+        self.model = Model("TheBloke/Llama-2-7B-Chat-GGUF")
+        url = "https://example.com/model_file.txt"
+        response = MagicMock(spec=requests.Response)
+        response.iter_content.return_value = [b"chunk1", b"chunk2", b"chunk3"]
+        total_size = 9
+        self.model.download(url, response, total_size)
+        mock_boto3_client.assert_called_once_with("s3", config=ANY)
+        mock_read_current_cluster_data.assert_called_once_with("bucket")
         mock_upload_to_s3.assert_called_once_with(
-            mock_response,
-            "models/TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf",
+            response, "models/TheBloke/Llama-2-7B-Chat-GGUF/model_file.txt", ANY
         )
-
-    @patch.object(Model, "download")
-    def test_download_all(self, mock_download: Mock) -> None:
-        urls = [
-            "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_0.gguf",
-            "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q2_K.gguf",
-        ]
-        sha256s: list[str | None] = [
-            "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b",
-            None,
-        ]
-
-        self.model.download_all(urls, sha256s)
-        self.assertEqual(mock_download.call_count, 2)
-        mock_download.assert_called_with(ANY, ANY)

--- a/tests/model_group/models/test_http_source_model.py
+++ b/tests/model_group/models/test_http_source_model.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import Mock, call, patch
+
+from paka.kube_resources.model_group.models.http_source_model import HttpSourceModel
+
+
+class TestHttpSourceModel(unittest.TestCase):
+    def setUp(self) -> None:
+        self.urls = ["http://example.com/file1.txt", "http://example.com/file2.txt"]
+        self.model = HttpSourceModel("test_model", self.urls)
+
+    def test_str(self) -> None:
+        self.assertEqual(str(self.model), "HttpSourceModel")
+
+    @patch(
+        "paka.kube_resources.model_group.models.http_source_model.HttpSourceManifest"
+    )
+    @patch("paka.kube_resources.model_group.models.http_source_model.to_yaml")
+    @patch("paka.kube_resources.model_group.models.http_source_model.boto3.resource")
+    def test_save_manifest_yml(
+        self,
+        mock_boto3_resource: Mock,
+        mock_to_yaml: Mock,
+        mock_HttpSourceManifest: Mock,
+    ) -> None:
+        mock_manifest = mock_HttpSourceManifest.return_value
+        mock_to_yaml.return_value = "manifest_yaml"
+        self.model.s3_bucket = "test_bucket"
+        mock_s3_object = mock_boto3_resource.return_value.Object.return_value
+        self.model.save_manifest_yml()
+        mock_HttpSourceManifest.assert_called_once_with(
+            name="test_model",
+            urls=[],
+            inference_devices=["cpu"],
+            quantization="GPTQ",
+            runtime="llama.cpp",
+            prompt_template="chatml",
+        )
+        mock_to_yaml.assert_called_once_with(
+            mock_manifest.model_dump(exclude_none=True)
+        )
+        mock_boto3_resource.assert_called_once_with("s3")
+        mock_s3_object.put.assert_called_once_with(Body="manifest_yaml")
+
+    @patch("paka.kube_resources.model_group.models.http_source_model.requests.get")
+    @patch.object(HttpSourceModel, "download")
+    def test_upload(self, mock_download: Mock, mock_requests_get: Mock) -> None:
+        mock_response = mock_requests_get.return_value
+        mock_response.headers.get.return_value = "100"
+        self.model.upload("http://example.com/file.txt")
+        mock_requests_get.assert_called_once_with(
+            "http://example.com/file.txt", stream=True
+        )
+
+    @patch(
+        "paka.kube_resources.model_group.models.http_source_model.concurrent.futures.ThreadPoolExecutor"
+    )
+    @patch("concurrent.futures.wait")
+    @patch.object(HttpSourceModel, "upload")
+    @patch.object(HttpSourceModel, "handle_upload_completion")
+    def test_upload_files(
+        self,
+        mock_handle_upload_completion: Mock,
+        mock_upload: Mock,
+        mock_wait: Mock,
+        mock_ThreadPoolExecutor: Mock,
+    ) -> None:
+        mock_executor = mock_ThreadPoolExecutor.return_value
+        mock_future1 = Mock()
+        mock_future2 = Mock()
+        mock_executor.submit.side_effect = [mock_future1, mock_future2]
+        self.model.upload_files()
+        mock_ThreadPoolExecutor.assert_called_once_with(max_workers=10)
+        mock_future1.result.assert_not_called()
+        mock_future2.result.assert_not_called()
+        mock_handle_upload_completion.assert_called_once()
+
+    @patch(
+        "paka.kube_resources.model_group.models.http_source_model.HttpSourceModel.save_manifest_yml"
+    )
+    @patch.object(HttpSourceModel, "clear_counter")
+    @patch.object(HttpSourceModel, "close_pbar")
+    @patch.object(HttpSourceModel, "logging_for_class")
+    def test_handle_upload_completion(
+        self,
+        mock_logging_for_class: Mock,
+        mock_close_pbar: Mock,
+        mock_clear_counter: Mock,
+        mock_save_manifest_yml: Mock,
+    ) -> None:
+        self.model.completed_files = []
+        self.model.handle_upload_completion()
+        mock_save_manifest_yml.assert_called_once()
+        self.assertEqual(self.model.completed_files, [])
+        mock_clear_counter.assert_called_once()
+        mock_close_pbar.assert_called_once()
+        mock_logging_for_class.assert_called_once_with("All files have been uploaded.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/model_group/models/test_hugging_face_model.py
+++ b/tests/model_group/models/test_hugging_face_model.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from paka.kube_resources.model_group.models.hugging_face_model import (
+    HuggingFaceModel,  # replace with the actual module name
+)
+
+
+class TestHuggingFaceModel(unittest.TestCase):
+    def test_define_urls(self) -> None:
+        # Arrange
+        model = HuggingFaceModel(
+            "TheBloke/Llama-2-7B-Chat-GGUF",
+            files=[
+                (
+                    "llama-2-7b-chat.Q4_0.gguf",
+                    "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b",
+                ),
+                (
+                    "llama-2-7b-chat.Q2_K.gguf",
+                    "c0dd304d761e8e05d082cc2902d7624a7f87858fdfaa4ef098330ffe767ff0d3",
+                ),
+            ],
+        )
+        for url in model.urls:
+            self.assertIn("https", url)
+        self.assertEqual(len(model.urls), len(model.sha256s))
+
+    @patch.object(HuggingFaceModel, "download_all")
+    def test_save_to_s3(self, mock_download_all: Mock) -> None:
+        """
+        Test case for the download method of the HuggingFaceModel class.
+
+        This test verifies that the download method correctly calls the `download_all` method
+        with the appropriate URLs and SHA256 hashes.
+
+        Args:
+            mock_download_all (Mock): A mock object representing the `download_all` method.
+
+        Returns:
+            None
+        """
+        # Arrange
+        model = HuggingFaceModel(
+            "TheBloke/Llama-2-7B-Chat-GGUF",
+            files=[
+                (
+                    "llama-2-7b-chat.Q4_0.gguf",
+                    "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b",
+                ),
+                (
+                    "llama-2-7b-chat.Q2_K.gguf",
+                    "c0dd304d761e8e05d082cc2902d7624a7f87858fdfaa4ef098330ffe767ff0d3",
+                ),
+            ],
+        )
+
+        # Act
+        model.save_to_s3()
+
+        # Assert
+        mock_download_all.assert_called_once_with(model.urls, model.sha256s)

--- a/tests/model_group/models/test_hugging_face_model.py
+++ b/tests/model_group/models/test_hugging_face_model.py
@@ -1,73 +1,192 @@
 import unittest
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
+from paka.kube_resources.model_group.models.base import MODEL_PATH_PREFIX
 from paka.kube_resources.model_group.models.hugging_face_model import (
     HuggingFaceModel,  # replace with the actual module name
 )
+from paka.utils import to_yaml
 
 
 class TestHuggingFaceModel(unittest.TestCase):
     def setUp(self) -> None:
-        with patch.object(HuggingFaceModel, "validate_files") as mock_validate_files:
-            mock_validate_files.return_value = [
-                "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf",
-                "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q2_K.gguf",
-            ]
-            self.model = HuggingFaceModel(
-                "TheBloke/Llama-2-7B-Chat-GGUF",
-                files=[
-                    "llama-2-7b-chat.Q4_0.gguf",
-                    "llama-2-7b-chat.Q2_K.gguf",
-                ],
-            )
+        self.model = HuggingFaceModel(
+            "TheBloke/Llama-2-7B-Chat-GGUF",
+            files=[
+                "llama-2-7b-chat.Q4_0.gguf",
+                "llama-2-7b-chat.Q2_K.gguf",
+            ],
+        )
 
     @patch.object(HuggingFaceModel, "get_file_info")
-    @patch.object(HuggingFaceModel, "upload_fs_to_s3")
-    @patch.object(HuggingFaceModel, "s3_file_exists")
-    @patch.object(HuggingFaceModel, "save_manifest_yml")
-    def test_upload_file_to_s3(
-        self,
-        mock_save_manifest_yml: Mock,
-        mock_s3_file_exists: Mock,
-        mock_upload_fs_to_s3: Mock,
-        mock_get_file_info: Mock,
+    @patch.object(HuggingFaceModel, "logging_for_class")
+    def test_validate_files(
+        self, mock_logging_for_class: Mock, mock_get_file_info: Mock
     ) -> None:
-        mock_s3_file_exists.return_value = False
-        mock_upload_fs_to_s3.return_value = (
-            "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b"
-        )
-
-        hf_file_path = "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf"
-        full_model_file_path = self.model.get_s3_file_path(hf_file_path)
-        mock_get_file_info.return_value = {
-            "size": 1024,
-            "lfs": {
-                "sha256": (
-                    "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b"
-                )
-            },
-        }
+        # Arrange
+        self.model.fs = MagicMock()
+        self.model.fs.glob = MagicMock()
+        self.model.fs.glob.side_effect = [
+            ["TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf"],
+            ["TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q2_K.gguf"],
+        ]
+        mock_get_file_info.side_effect = [
+            {"size": 100, "lfs": {"sha256": "abc123"}},
+            {"size": 200, "lfs": {"sha256": "edb322"}},
+        ]
 
         # Act
-        self.model.s3 = MagicMock()
-        self.model.s3.create_multipart_upload = MagicMock()
-        self.model.s3.create_multipart_upload.return_value = {"UploadId": "test"}
-        self.model.upload_file_to_s3(hf_file_path)
+        self.model.validate_files()
 
         # Assert
-        mock_get_file_info.assert_called_once_with(hf_file_path)
-        mock_upload_fs_to_s3.assert_called_once_with(
-            ANY, 1024, full_model_file_path, "test"
+        mock_logging_for_class.assert_not_called()
+
+    @patch.object(HuggingFaceModel, "get_file_info")
+    @patch.object(HuggingFaceModel, "logging_for_class")
+    def test_validate_files_file_not_found(
+        self, mock_logging_for_class: Mock, mock_get_file_info: Mock
+    ) -> None:
+        # Arrange
+        self.model.fs = MagicMock()
+        self.model.fs.glob = MagicMock()
+        self.model.fs.glob.return_value = []
+
+        # Act
+        self.model.validate_files()
+
+        # Assert
+        self.assertEqual(mock_logging_for_class.call_count, 2)
+        mock_get_file_info.assert_not_called()
+
+    def test_get_file_info(self) -> None:
+        # Arrange
+        hf_file_path = "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf"
+        expected_file_info = {"size": 100, "lfs": {"sha256": "abc123"}}
+        self.model.fs = MagicMock()
+        self.model.fs.stat = MagicMock()
+        self.model.fs.stat.return_value = expected_file_info
+
+        # Act
+        file_info = self.model.get_file_info(hf_file_path)
+
+        # Assert
+        self.assertEqual(file_info, expected_file_info)
+        self.model.fs.stat.assert_called_once_with(hf_file_path)
+
+    @patch.object(HuggingFaceModel, "get_file_info")
+    @patch.object(HuggingFaceModel, "download")
+    def test_upload(self, mock_download: Mock, mock_get_file_info: Mock) -> None:
+        # Arrange
+        hf_file_path = "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf"
+        hf_file = MagicMock()
+        self.model.fs = MagicMock()
+        self.model.fs.open = MagicMock()
+        self.model.fs.open.return_value.__enter__.return_value = hf_file
+        mock_download = MagicMock()
+        mock_get_file_info.return_value = {"size": 100, "lfs": {"sha256": "abc123"}}
+        sha256 = "abc123"
+
+        # Act
+        self.model.upload(hf_file_path)
+
+        # Assert
+        self.model.fs.open.assert_called_once_with(hf_file_path, "rb")
+        mock_download.assert_called_once_with(hf_file_path, hf_file, 100, sha256)
+
+    @patch("boto3.resource")
+    @patch("paka.utils.to_yaml")
+    @patch.object(HuggingFaceModel, "logging_for_class")
+    def test_save_manifest_yml(
+        self,
+        mock_logging_for_class: Mock,
+        mock_to_yaml: Mock,
+        mock_boto3_resource: Mock,
+    ) -> None:
+        # Arrange
+        self.model.completed_files = [
+            ("TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf", "abc123"),
+            ("TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q2_K.gguf", "edb322"),
+        ]
+        self.model.s3_bucket = "my-bucket"
+        mock_s3_resource = mock_boto3_resource.return_value
+        mock_s3_object = mock_s3_resource.Object.return_value
+
+        # Act
+        self.model.save_manifest_yml()
+
+        # Assert
+        expected_manifest = {
+            "repo_id": "TheBloke/Llama-2-7B-Chat-GGUF",
+            "files": [
+                ("TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf", "abc123"),
+                ("TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q2_K.gguf", "edb322"),
+            ],
+            "inference_devices": ["cpu"],
+            "quantization": "GPTQ",
+            "runtime": "llama.cpp",
+            "prompt_template": "chatml",
+        }
+
+        expected_manifest_yml = to_yaml(expected_manifest)
+        mock_s3_object.put.assert_called_once_with(Body=expected_manifest_yml)
+        mock_logging_for_class.assert_called_once_with(
+            f"manifest.yml file saved to {MODEL_PATH_PREFIX}/TheBloke/Llama-2-7B-Chat-GGUF/manifest.yml"
         )
 
-    @patch.object(HuggingFaceModel, "upload_file_to_s3")
-    @patch.object(HuggingFaceModel, "save_manifest_yml")
+    @patch("concurrent.futures.wait")
+    @patch.object(HuggingFaceModel, "logging_for_class")
+    @patch.object(HuggingFaceModel, "validate_files")
+    @patch.object(HuggingFaceModel, "create_pbar")
+    @patch.object(HuggingFaceModel, "upload")
+    @patch.object(HuggingFaceModel, "handle_upload_completion")
     def test_upload_files(
-        self, mock_save_manifest_yml: Mock, mock_upload_file_to_s3: Mock
+        self,
+        mock_handle_upload_completion: Mock,
+        mock_upload: Mock,
+        mock_create_pbar: Mock,
+        mock_validate_files: Mock,
+        mock_logging_for_class: Mock,
+        mock_wait: Mock,
     ) -> None:
+        # Arrange
+        self.model.files = [
+            "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf",
+            "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q2_K.gguf",
+        ]
+
         # Act
         self.model.upload_files()
 
         # Assert
-        self.assertEqual(mock_upload_file_to_s3.call_count, 2)
-        mock_upload_file_to_s3.assert_called_with(ANY)
+        mock_logging_for_class.assert_called_once_with("Uploading files to S3...")
+        mock_validate_files.assert_called_once()
+        self.assertEqual(mock_upload.call_count, 2)
+        mock_handle_upload_completion.assert_called_once()
+
+    @patch.object(HuggingFaceModel, "logging_for_class")
+    @patch.object(HuggingFaceModel, "save_manifest_yml")
+    @patch.object(HuggingFaceModel, "clear_counter")
+    @patch.object(HuggingFaceModel, "close_pbar")
+    def test_handle_upload_completion(
+        self,
+        mock_close_pbar: Mock,
+        mock_clear_counter: Mock,
+        mock_save_manifest_yml: Mock,
+        mock_logging_for_class: Mock,
+    ) -> None:
+        # Arrange
+        self.model.completed_files = [
+            ("TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf", "abc123"),
+            ("TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q2_K.gguf", "edb322"),
+        ]
+        mock_logging_for_class = MagicMock()
+
+        # Act
+        self.model.handle_upload_completion()
+
+        # Assert
+        mock_save_manifest_yml.assert_called_once()
+        self.assertEqual(self.model.completed_files, [])
+        mock_clear_counter.assert_called_once()
+        mock_close_pbar.assert_called_once()
+        mock_logging_for_class.assert_called_once_with("All files have been uploaded.")

--- a/tests/model_group/models/test_hugging_face_model.py
+++ b/tests/model_group/models/test_hugging_face_model.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 from paka.kube_resources.model_group.models.hugging_face_model import (
     HuggingFaceModel,  # replace with the actual module name
@@ -8,19 +8,18 @@ from paka.kube_resources.model_group.models.hugging_face_model import (
 
 class TestHuggingFaceModel(unittest.TestCase):
     def setUp(self) -> None:
-        self.model = HuggingFaceModel(
-            "TheBloke/Llama-2-7B-Chat-GGUF",
-            files=[
-                "llama-2-7b-chat.Q4_0.gguf",
-                "llama-2-7b-chat.Q2_K.gguf",
-            ],
-        )
-
-    def test_validate_files(self) -> None:
-        # Assert
-        self.assertEqual(len(self.model.files), 2)
-        for file in self.model.files:
-            self.assertTrue(file.startswith(self.model.repo_id))
+        with patch.object(HuggingFaceModel, "validate_files") as mock_validate_files:
+            mock_validate_files.return_value = [
+                "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf",
+                "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q2_K.gguf",
+            ]
+            self.model = HuggingFaceModel(
+                "TheBloke/Llama-2-7B-Chat-GGUF",
+                files=[
+                    "llama-2-7b-chat.Q4_0.gguf",
+                    "llama-2-7b-chat.Q2_K.gguf",
+                ],
+            )
 
     @patch.object(HuggingFaceModel, "get_file_info")
     @patch.object(HuggingFaceModel, "upload_fs_to_s3")
@@ -35,9 +34,9 @@ class TestHuggingFaceModel(unittest.TestCase):
     ) -> None:
         mock_s3_file_exists.return_value = False
         mock_upload_fs_to_s3.return_value = (
-            "test_upload_id",
-            "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b",
+            "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b"
         )
+
         hf_file_path = "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf"
         full_model_file_path = self.model.get_s3_file_path(hf_file_path)
         mock_get_file_info.return_value = {
@@ -50,14 +49,22 @@ class TestHuggingFaceModel(unittest.TestCase):
         }
 
         # Act
+        self.model.s3 = MagicMock()
+        self.model.s3.create_multipart_upload = MagicMock()
+        self.model.s3.create_multipart_upload.return_value = {"UploadId": "test"}
         self.model.upload_file_to_s3(hf_file_path)
 
         # Assert
         mock_get_file_info.assert_called_once_with(hf_file_path)
-        mock_upload_fs_to_s3.assert_called_once_with(ANY, 1024, full_model_file_path)
+        mock_upload_fs_to_s3.assert_called_once_with(
+            ANY, 1024, full_model_file_path, "test"
+        )
 
     @patch.object(HuggingFaceModel, "upload_file_to_s3")
-    def test_upload_files(self, mock_upload_file_to_s3: Mock) -> None:
+    @patch.object(HuggingFaceModel, "save_manifest_yml")
+    def test_upload_files(
+        self, mock_save_manifest_yml: Mock, mock_upload_file_to_s3: Mock
+    ) -> None:
         # Act
         self.model.upload_files()
 

--- a/tests/model_group/models/test_hugging_face_model.py
+++ b/tests/model_group/models/test_hugging_face_model.py
@@ -25,8 +25,10 @@ class TestHuggingFaceModel(unittest.TestCase):
     @patch.object(HuggingFaceModel, "get_file_info")
     @patch.object(HuggingFaceModel, "upload_fs_to_s3")
     @patch.object(HuggingFaceModel, "s3_file_exists")
+    @patch.object(HuggingFaceModel, "save_manifest_yml")
     def test_upload_file_to_s3(
         self,
+        mock_save_manifest_yml: Mock,
         mock_s3_file_exists: Mock,
         mock_upload_fs_to_s3: Mock,
         mock_get_file_info: Mock,

--- a/tests/model_group/models/test_hugging_face_model.py
+++ b/tests/model_group/models/test_hugging_face_model.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from paka.kube_resources.model_group.models.hugging_face_model import (
     HuggingFaceModel,  # replace with the actual module name
@@ -7,56 +7,58 @@ from paka.kube_resources.model_group.models.hugging_face_model import (
 
 
 class TestHuggingFaceModel(unittest.TestCase):
-    def test_define_urls(self) -> None:
-        # Arrange
-        model = HuggingFaceModel(
+    def setUp(self) -> None:
+        self.model = HuggingFaceModel(
             "TheBloke/Llama-2-7B-Chat-GGUF",
             files=[
-                (
-                    "llama-2-7b-chat.Q4_0.gguf",
-                    "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b",
-                ),
-                (
-                    "llama-2-7b-chat.Q2_K.gguf",
-                    "c0dd304d761e8e05d082cc2902d7624a7f87858fdfaa4ef098330ffe767ff0d3",
-                ),
+                "llama-2-7b-chat.Q4_0.gguf",
+                "llama-2-7b-chat.Q2_K.gguf",
             ],
         )
-        for url in model.urls:
-            self.assertIn("https", url)
-        self.assertEqual(len(model.urls), len(model.sha256s))
 
-    @patch.object(HuggingFaceModel, "download_all")
-    def test_save_to_s3(self, mock_download_all: Mock) -> None:
-        """
-        Test case for the download method of the HuggingFaceModel class.
+    def test_validate_files(self) -> None:
+        # Assert
+        self.assertEqual(len(self.model.files), 2)
+        for file in self.model.files:
+            self.assertTrue(file.startswith(self.model.repo_id))
 
-        This test verifies that the download method correctly calls the `download_all` method
-        with the appropriate URLs and SHA256 hashes.
-
-        Args:
-            mock_download_all (Mock): A mock object representing the `download_all` method.
-
-        Returns:
-            None
-        """
-        # Arrange
-        model = HuggingFaceModel(
-            "TheBloke/Llama-2-7B-Chat-GGUF",
-            files=[
-                (
-                    "llama-2-7b-chat.Q4_0.gguf",
-                    "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b",
-                ),
-                (
-                    "llama-2-7b-chat.Q2_K.gguf",
-                    "c0dd304d761e8e05d082cc2902d7624a7f87858fdfaa4ef098330ffe767ff0d3",
-                ),
-            ],
+    @patch.object(HuggingFaceModel, "get_file_info")
+    @patch.object(HuggingFaceModel, "upload_fs_to_s3")
+    @patch.object(HuggingFaceModel, "s3_file_exists")
+    def test_upload_file_to_s3(
+        self,
+        mock_s3_file_exists: Mock,
+        mock_upload_fs_to_s3: Mock,
+        mock_get_file_info: Mock,
+    ) -> None:
+        mock_s3_file_exists.return_value = False
+        mock_upload_fs_to_s3.return_value = (
+            "test_upload_id",
+            "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b",
         )
+        hf_file_path = "TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_0.gguf"
+        full_model_file_path = self.model.get_s3_file_path(hf_file_path)
+        mock_get_file_info.return_value = {
+            "size": 1024,
+            "lfs": {
+                "sha256": (
+                    "9958ee9b670594147b750bbc7d0540b928fa12dcc5dd4c58cc56ed2eb85e371b"
+                )
+            },
+        }
 
         # Act
-        model.save_to_s3()
+        self.model.upload_file_to_s3(hf_file_path)
 
         # Assert
-        mock_download_all.assert_called_once_with(model.urls, model.sha256s)
+        mock_get_file_info.assert_called_once_with(hf_file_path)
+        mock_upload_fs_to_s3.assert_called_once_with(ANY, 1024, full_model_file_path)
+
+    @patch.object(HuggingFaceModel, "upload_file_to_s3")
+    def test_upload_files(self, mock_upload_file_to_s3: Mock) -> None:
+        # Act
+        self.model.upload_files()
+
+        # Assert
+        self.assertEqual(mock_upload_file_to_s3.call_count, 2)
+        mock_upload_file_to_s3.assert_called_with(ANY)

--- a/tests/model_group/test_model.py
+++ b/tests/model_group/test_model.py
@@ -71,13 +71,13 @@ def test_download_model() -> None:
         return_value=False,
     ) as mock_exists, patch(
         "paka.kube_resources.model_group.model.download_file_to_s3",
-        return_value=SUPPORTED_MODELS["llama2-7b"].sha256,
+        return_value=SUPPORTED_MODELS["mistral-7b"].sha256,
     ) as mock_download, patch(
         "paka.kube_resources.model_group.model.delete_s3_file"
     ) as mock_delete, patch(
         "paka.kube_resources.model_group.model.save_string_to_s3"
     ) as mock_save:
-        download_model("llama2-7b")
+        download_model("mistral-7b")
 
         mock_exists.assert_called_once()
         mock_download.assert_called_once()


### PR DESCRIPTION
I have established a list objects named SUPPORTED_MODELS_V2,  SUPPORTED_MODELS_V3 within the supported_model.py file.

If the http source model name exists in the SUPPORTED_MODELS_V3 list object Or the hugging face model name exists in the SUPPORTED_MODELS_V2 list object, the system will employ the new HttpSouceModel Or HuggingFaceModel for downloading/uploading to s3. Otherwise, it will resort to the old logic.

HuggingFaceModel {
  repo_id: "TheBloke/CapybaraHermes-2.5-Mistral-7B-GPTQ",
  files: ["*.json", "model.safetensors"],
  inference_devices: ["cpu"], // gpu, tpu, etc
  quantization: "GPTQ", // GPTQ, AWQ, GGUF_Q4_0, etc
  runtime: "llama.cpp", // vLLM, pytorch, etc
  prompt_template: "chatml", // chatml, llama-2, gemma, etc.
}
http_source {
  urls: ["https://thebloke.github.io/CapybaraHermes-2.5-Mistral-7B-GPTQ/model.safetensors", ...]
  inference_devices: ["cpu"], // gpu, tpu, etc
  quantization: "GPTQ", // GPTQ, AWQ, GGUF_Q4_0, etc
  runtime: "llama.cpp", // vLLM, pytorch, etc
  prompt_template: "chatml", // chatml, llama-2, gemma, etc.
}